### PR TITLE
Internationalisation implemented; some code clean-up

### DIFF
--- a/HeaderFooter.class.debug.php
+++ b/HeaderFooter.class.debug.php
@@ -12,25 +12,30 @@ class HeaderFooter
 		$action = $op->parserOptions()->getUser()->getRequest()->getVal("action");
 		if ( ($action == 'edit') || ($action == 'submit') || ($action == 'history') )
 			return true;
-
+			
 		global $wgTitle, $wgOut;
-
+		
 		$ns = $wgTitle->getNsText();
 		$name = $wgTitle->getPrefixedDBKey();
 		$text = $parserOutput->getText();
 
 		$categories = $wgTitle->getParentCategories();
 		$categories = array_keys( $categories) ;
-		$categories = array_map(
+var_dump( $categories ) ;
+		$categories = array_map( 
 			function( $cat ){ return Title::newFromText( $cat, NS_CATEGORY )->getText(); },
 			$categories
 		);
+var_dump( $categories ) ;
+
+//MWDebug::warning( "ns=" . $ns ) ;
+//MWDebug::warning( "name=" . $name ) ;
 
 		$nsheader = "hf-nsheader-$ns";
-		$nsfooter = "hf-nsfooter-$ns";
-
+		$nsfooter = "hf-nsfooter-$ns";	  
+ 
 		$header = "hf-header-$name";
-		$footer = "hf-footer-$name";
+		$footer = "hf-footer-$name";		
 
 		/**
 		 * headers/footers are wrapped around page content.
@@ -41,49 +46,62 @@ class HeaderFooter
 		$text = '<div class="hf-nsheader">'.self::conditionalInclude( $text, '__NONSHEADER__', $nsheader ).'</div>'.$text;
 
 		foreach( $categories as &$category ) {
+MWDebug::warning( "cat=" . $category) ;
 			$catheader = "hf-catheader-$category" ;
 			$text = '<div class="hf-catheader">'.self::conditionalInclude( $text, '__NOCATHEADER__', $catheader ).'</div>'.$text;
 			$catfooter = "hf-catfooter-$category" ;
 			$text .= '<div class="hf-catfooter">'.self::conditionalInclude( $text, '__NOCATFOOTER__', $catfooter ).'</div>';
 		}
+		////
 
 		$text .= '<div class="hf-footer">'.self::conditionalInclude( $text, '__NOFOOTER__', $footer ).'</div>';
 		$text .= '<div class="hf-nsfooter">'.self::conditionalInclude( $text, '__NONSFOOTER__', $nsfooter ).'</div>';
-
+		
 		$parserOutput->setText( $text );
-
+		
 		return true;
-	}
+	}	 
 
 	/**
 	 * Verifies & Strips ''disable command'', returns $content if all OK.
 	 */
-	static function conditionalInclude( &$text, $disableWord, &$msgId )
-	{
-		// is there a disable command lurking around?
-		$disable = strpos( $text, $disableWord ) !== false;
+    static function conditionalInclude( &$text, $disableWord, &$msgId )
+    {
+        // is there a disable command lurking around?
+        $disable = strpos( $text, $disableWord ) !== false;
 
-		// if there is, get rid of it
-		// make sure that the disableWord does not break the REGEX below!
-		$text = preg_replace('/'.$disableWord.'/si', '', $text );
+//MWDebug::warning( "msgId=" . $msgId ) ;
+//MWDebug::warning( "disable=" . $disable) ;
 
-		// if there is a disable command, then don't return anything
-		if ($disable)
-			return null;
+        // if there is, get rid of it
+        // make sure that the disableWord does not break the REGEX below!
+        $text = preg_replace('/'.$disableWord.'/si', '', $text );
+ 
+//MWDebug::warning( "text=" . $text) ;
 
-		//$msgText = wfMsgExt( $msgId, array( 'parseinline' ) );
-		//https://www.mediawiki.org/wiki/Manual:Messages_API
-		$msgText = wfMessage( $msgId) -> parse() ;
+        // if there is a disable command, then don't return anything
+        if ($disable)
+            return null;
+			
+//https://www.mediawiki.org/wiki/Manual:Messages_API
+        $msgText = wfMessage( $msgId) -> parse() ;
+//        $msgText = wfMsgExt( $msgId, array( 'parseinline' ) );
 
-		// don't need to bother if there is no content.
-		if (empty( $msgText ))
-			return null;
+//MWDebug::warning( "msgText=" . $msgText ) ;
+//MWDebug::warning( "wfEmptyMsg=" . wfEmptyMsg( $msgId, $msgText )) ;
+//MWDebug::warning( "EmptyMsg=" . wfMessage( $msgId )->inContentLanguage()->isBlank() ) ;
 
-		//if (wfEmptyMsg( $msgId, $msgText ))
-		//https://www.mediawiki.org/wiki/Manual:Messages_API
-		if ( wfMessage( $msgId )->inContentLanguage()->isBlank() )
-			return null;
+        // don't need to bother if there is no content.
+        if (empty( $msgText ))
+            return null;
+ 
+//https://www.mediawiki.org/wiki/Manual:Messages_API
+        if ( wfMessage( $msgId )->inContentLanguage()->isBlank() ) 
+//        if (wfEmptyMsg( $msgId, $msgText ))
+            return null;
+ 
+        return $msgText;
+    }
 
-		return $msgText;
-	}
+		
 } // END CLASS DEFINITION

--- a/HeaderFooter.class.php
+++ b/HeaderFooter.class.php
@@ -19,6 +19,9 @@ class HeaderFooter
 		$ns = $wgTitle->getNsText();
 		$name = $wgTitle->getPrefixedDBKey();
 
+		$categories = $wgTitle->getParentCategories();
+		$categories = array_keys( $categories) ;
+
 		$text = $parserOutput->getText();
 
 		$nsheader = "hf-nsheader-$ns";
@@ -29,6 +32,22 @@ class HeaderFooter
 
 		$text = '<div class="hf-header">'.self::conditionalInclude( $text, '__NOHEADER__', $header ).'</div>'.$text;
 		$text = '<div class="hf-nsheader">'.self::conditionalInclude( $text, '__NONSHEADER__', $nsheader ).'</div>'.$text;
+
+		/*
+		* headers/footers pages: hf-cat{header,footer}-<NAME OF CATEGORY>
+		* new token __NOCATHEADER__
+		* using div class="hf-cat{header,footer}"
+		*/
+		$NS14 = "Kategorie" ;	// must be internationalized but don't know how
+					// need value of nstab-category in i18n-files
+		$once = 1 ;		// cannot pass constant 1 to str_replace()
+		foreach( $categories as &$category ) {
+	        $cat = str_replace( $NS14.":", "", $category, $once) ;
+	        $catheader = "hf-catheader-$cat" ;
+	        $text = '<div class="hf-catheader">'.self::conditionalInclude( $text, '__NOCATHEADER__', $catheader ).'</div>'.$text;
+        	$catfooter = "hf-catfooter-$cat" ;
+        	$text .= '<div class="hf-catfooter">'.self::conditionalInclude( $text, '__NOCATFOOTER__', $catfooter ).'</div>';
+}
 
 		$text .= '<div class="hf-footer">'.self::conditionalInclude( $text, '__NOFOOTER__', $footer ).'</div>';
 		$text .= '<div class="hf-nsfooter">'.self::conditionalInclude( $text, '__NONSFOOTER__', $nsfooter ).'</div>';


### PR DESCRIPTION
The internationalisation works the way you had suggested. The code works well here with multiple category headers/footers in addition to namespace headers/footers.

While I was at it, I stumbled over https://www.mediawiki.org/wiki/Manual:Messages_API which says to replace calls to deprecated wfMsg-functions. Now I have two changes in this pull request but the second one is easily separated as I left the old commands there as comments.

I noticed that the second function was formatted in a different fashion than the first. So I also changed that.

Cheers!
sm
