### PR TITLE
Optionally load headers and footers asynchronously

### DIFF
--- a/ApiGetHeaderFooter.php
+++ b/ApiGetHeaderFooter.php
@@ -13,8 +13,6 @@
 class ApiGetHeaderFooter extends ApiBase {
 
 	public function execute() {
-		global $wgUser;
-
 
 		$params = $this->extractRequestParams();
 		$contextTitle = Title::newFromDBkey( $params['contexttitle'] );
@@ -22,11 +20,8 @@ class ApiGetHeaderFooter extends ApiBase {
 			$this->dieUsage( "Not a valid contexttitle.", 'notarget' );
 		}
 
-		// RequestContext::getMain()->setTitle( $contextTitle );
-
 		$messageId = $params['messageid'];
 
-		// $messageText = wfMessage( $msgId )->setContext(  $params['contexttitle'] )->parse();
 		$messageText = wfMessage( $messageId )->title( $contextTitle )->text();
 
 		// don't need to bother if there is no content.
@@ -38,9 +33,13 @@ class ApiGetHeaderFooter extends ApiBase {
 			$messageText = '';
 		}
 
-		global $wgParser, $wgUser;
-		$parser = $wgParser;
-		$messageText = $parser->parse( $messageText, $contextTitle, ParserOptions::newFromUser( $wgUser ) )->getText();
+		global $wgParser;
+
+		$messageText = $wgParser->parse(
+			$messageText,
+			$contextTitle,
+			ParserOptions::newFromUser( $this->getUser() )
+		)->getText();
 
 		$this->getResult()->addValue( null, $this->getModuleName(), array( 'result' => $messageText ) );
 
@@ -69,14 +68,6 @@ class ApiGetHeaderFooter extends ApiBase {
 		);
 	}
 
-	// "apihelp-getheaderfooter-description": "Retrieve the parsed output of a header or footer in the context of a certain page.",
-	// "apihelp-getheaderfooter-summary": "Retrieve the parsed output of a header or footer in the context of a certain page.",
-	// "apihelp-getheaderfooter-param-contexttitle": "The title of the page that the header or footer is being added to.",
-	// "apihelp-getheaderfooter-param-messageid": "Which header or footer is being requested (e.g. a namespace header)",
-	// "apihelp-getheaderfooter-example-1": "Approve Revision 12345",
-
-
-
 	public function mustBePosted() {
 		return false;
 	}
@@ -85,16 +76,4 @@ class ApiGetHeaderFooter extends ApiBase {
 		return false;
 	}
 
-	/*
-	 * CSRF Token must be POSTed
-	 * use parameter name 'token'
-	 * No need to document, this is automatically done by ApiBase
-	 */
-	// public function needsToken() {
-	// 	return 'csrf';
-	// }
-
-	// public function getTokenSalt() {
-	// 	return 'e-ar';
-	// }
 }

--- a/ApiGetHeaderFooter.php
+++ b/ApiGetHeaderFooter.php
@@ -15,6 +15,7 @@ class ApiGetHeaderFooter extends ApiBase {
 	public function execute() {
 		global $wgUser;
 
+
 		$params = $this->extractRequestParams();
 		$contextTitle = Title::newFromDBkey( $params['contexttitle'] );
 		if ( ! $contextTitle ) {
@@ -26,7 +27,7 @@ class ApiGetHeaderFooter extends ApiBase {
 		$messageId = $params['messageid'];
 
 		// $messageText = wfMessage( $msgId )->setContext(  $params['contexttitle'] )->parse();
-		$messageText = wfMessage( $messageId )->title( $contextTitle )->parse();
+		$messageText = wfMessage( $messageId )->title( $contextTitle )->text();
 
 		// don't need to bother if there is no content.
 		if ( empty( $messageText ) ) {
@@ -37,6 +38,9 @@ class ApiGetHeaderFooter extends ApiBase {
 			$messageText = '';
 		}
 
+		global $wgParser, $wgUser;
+		$parser = $wgParser;
+		$messageText = $parser->parse( $messageText, $contextTitle, ParserOptions::newFromUser( $wgUser ) )->getText();
 
 		$this->getResult()->addValue( null, $this->getModuleName(), array( 'result' => $messageText ) );
 

--- a/ApiGetHeaderFooter.php
+++ b/ApiGetHeaderFooter.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * API module for MediaWiki's HeaderFooter extension.
+ *
+ * @author James Montalvo
+ * @since Version 1.0
+ */
+
+/**
+ * API module to review revisions
+ */
+class ApiGetHeaderFooter extends ApiBase {
+
+	public function execute() {
+		global $wgUser;
+
+		$params = $this->extractRequestParams();
+		$contextTitle = Title::newFromDBkey( $params['contexttitle'] );
+		if ( ! $contextTitle ) {
+			$this->dieUsage( "Not a valid contexttitle.", 'notarget' );
+		}
+
+		// RequestContext::getMain()->setTitle( $contextTitle );
+
+		$messageId = $params['messageid'];
+
+		// $messageText = wfMessage( $msgId )->setContext(  $params['contexttitle'] )->parse();
+		$messageText = wfMessage( $messageId )->title( $contextTitle )->parse();
+
+		// don't need to bother if there is no content.
+		if ( empty( $messageText ) ) {
+			$messageText = '';
+		}
+
+		if ( wfMessage( $messageId )->inContentLanguage()->isBlank() ) {
+			$messageText = '';
+		}
+
+
+		$this->getResult()->addValue( null, $this->getModuleName(), array( 'result' => $messageText ) );
+
+	}
+
+	public function getAllowedParams() {
+		return array(
+			'contexttitle' => array(
+				ApiBase::PARAM_REQUIRED => true,
+				ApiBase::PARAM_TYPE => 'string'
+			),
+			'messageid' => array(
+				ApiBase::PARAM_REQUIRED => true,
+				ApiBase::PARAM_TYPE => 'string'
+			)
+		);
+	}
+
+	/**
+	 * @see ApiBase::getExamplesMessages()
+	 */
+	protected function getExamplesMessages() {
+		return array(
+			'action=getheaderfooter&contexttitle=Main_Page&messageid=Hf-nsfooter-'
+				=> 'apihelp-getheaderfooter-example-1',
+		);
+	}
+
+	// "apihelp-getheaderfooter-description": "Retrieve the parsed output of a header or footer in the context of a certain page.",
+	// "apihelp-getheaderfooter-summary": "Retrieve the parsed output of a header or footer in the context of a certain page.",
+	// "apihelp-getheaderfooter-param-contexttitle": "The title of the page that the header or footer is being added to.",
+	// "apihelp-getheaderfooter-param-messageid": "Which header or footer is being requested (e.g. a namespace header)",
+	// "apihelp-getheaderfooter-example-1": "Approve Revision 12345",
+
+
+
+	public function mustBePosted() {
+		return false;
+	}
+
+	public function isWriteMode() {
+		return false;
+	}
+
+	/*
+	 * CSRF Token must be POSTed
+	 * use parameter name 'token'
+	 * No need to document, this is automatically done by ApiBase
+	 */
+	// public function needsToken() {
+	// 	return 'csrf';
+	// }
+
+	// public function getTokenSalt() {
+	// 	return 'e-ar';
+	// }
+}

--- a/ApiGetHeaderFooter.php
+++ b/ApiGetHeaderFooter.php
@@ -4,7 +4,7 @@
  * API module for MediaWiki's HeaderFooter extension.
  *
  * @author James Montalvo
- * @since Version 1.0
+ * @since Version 3.0
  */
 
 /**

--- a/HeaderFooter.class.php
+++ b/HeaderFooter.class.php
@@ -28,8 +28,8 @@ class HeaderFooter
 
 		$parserOutput->setText( $nsheader . $header . $text . $footer . $nsfooter );
 
-		global $egHeaderFooterDynamicLoad;
-		if ( $egHeaderFooterDynamicLoad ) {
+		global $egHeaderFooterEnableAsyncHeader, $egHeaderFooterEnableAsyncFooter;
+		if ( $egHeaderFooterEnableAsyncFooter || $egHeaderFooterEnableAsyncHeader ) {
 			$op->addModules( 'ext.headerfooter.dynamicload' );
 		}
 
@@ -56,8 +56,14 @@ class HeaderFooter
 		$msgId = "$class-$unique"; // also HTML ID
 		$div = "<div class='$class' id='$msgId'>";
 
-		global $egHeaderFooterDynamicLoad;
-		if ( $egHeaderFooterDynamicLoad ) {
+		global $egHeaderFooterEnableAsyncHeader, $egHeaderFooterEnableAsyncFooter;
+
+		$isHeader = $class === 'hf-nsheader' || $class === 'hf-header';
+		$isFooter = $class === 'hf-nsfooter' || $class === 'hf-footer';
+
+		if ( ( $egHeaderFooterEnableAsyncFooter && $isFooter )
+			|| ( $egHeaderFooterEnableAsyncHeader && $isHeader ) ) {
+
 			// Just drop an empty div into the page. Will fill it with async
 			// request after page load
 			return $div . '</div>';
@@ -76,6 +82,17 @@ class HeaderFooter
 
 			return $div . $msgText . '</div>';
 		}
+	}
+
+	public static function onResourceLoaderGetConfigVars ( array &$vars ) {
+		global $egHeaderFooterEnableAsyncHeader, $egHeaderFooterEnableAsyncFooter;
+
+		$vars['egHeaderFooter'] = [
+			'enableAsyncHeader' => $egHeaderFooterEnableAsyncHeader,
+			'enableAsyncFooter' => $egHeaderFooterEnableAsyncFooter,
+		];
+
+		return true;
 	}
 
 }

--- a/HeaderFooter.class.php
+++ b/HeaderFooter.class.php
@@ -21,19 +21,17 @@ class HeaderFooter
 
 		$text = $parserOutput->getText();
 
-		$nsheader = "hf-nsheader-$ns";
-		$nsfooter = "hf-nsfooter-$ns";
+		$nsheader = self::conditionalInclude( $text, '__NONSHEADER__', 'hf-nsheader', $ns );
+		$header   = self::conditionalInclude( $text, '__NOHEADER__',   'hf-header', $name );
+		$footer   = self::conditionalInclude( $text, '__NOFOOTER__',   'hf-footer', $name );
+		$nsfooter = self::conditionalInclude( $text, '__NONSFOOTER__', 'hf-nsfooter', $ns );
 
-		$header = "hf-header-$name";
-		$footer = "hf-footer-$name";
+		$parserOutput->setText( $nsheader . $header . $text . $footer . $nsfooter );
 
-		$text = '<div class="hf-header">'.self::conditionalInclude( $text, '__NOHEADER__', $header ).'</div>'.$text;
-		$text = '<div class="hf-nsheader">'.self::conditionalInclude( $text, '__NONSHEADER__', $nsheader ).'</div>'.$text;
-
-		$text .= '<div class="hf-footer">'.self::conditionalInclude( $text, '__NOFOOTER__', $footer ).'</div>';
-		$text .= '<div class="hf-nsfooter">'.self::conditionalInclude( $text, '__NONSFOOTER__', $nsfooter ).'</div>';
-
-		$parserOutput->setText( $text );
+		global $egHeaderFooterDynamicLoad;
+		if ( $egHeaderFooterDynamicLoad ) {
+			$op->addModules( 'ext.headerfooter.dynamicload' );
+		}
 
 		return true;
 	}
@@ -41,8 +39,8 @@ class HeaderFooter
 	/**
 	 * Verifies & Strips ''disable command'', returns $content if all OK.
 	 */
-	static function conditionalInclude( &$text, $disableWord, &$msgId ) {
-		
+	static function conditionalInclude( &$text, $disableWord, $class, $unique ) {
+
 		// is there a disable command lurking around?
 		$disable = strpos( $text, $disableWord ) !== false;
 
@@ -55,18 +53,29 @@ class HeaderFooter
 			return null;
 		}
 
-		$msgText = wfMessage( $msgId )->parse();
+		$msgId = "$class-$unique"; // also HTML ID
+		$div = "<div class='$class' id='$msgId'>";
 
-		// don't need to bother if there is no content.
-		if ( empty( $msgText ) ) {
-			return null;
+		global $egHeaderFooterDynamicLoad;
+		if ( $egHeaderFooterDynamicLoad ) {
+			// Just drop an empty div into the page. Will fill it with async
+			// request after page load
+			return $div . '</div>';
 		}
+		else {
+			$msgText = wfMessage( $msgId )->parse();
 
-		if ( wfMessage( $msgId )->inContentLanguage()->isBlank() ) {
-			return null;
- 		}
+			// don't need to bother if there is no content.
+			if ( empty( $msgText ) ) {
+				return null;
+			}
 
-		return $msgText;
+			if ( wfMessage( $msgId )->inContentLanguage()->isBlank() ) {
+				return null;
+			}
+
+			return $div . $msgText . '</div>';
+		}
 	}
 
 }

--- a/extension.json
+++ b/extension.json
@@ -13,5 +13,20 @@
 			"HeaderFooter::hOutputPageParserOutput"
 		]
 	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "modules",
+		"remoteExtPath": "HeaderFooter/modules"
+	},
+	"ResourceModules": {
+		"ext.headerfooter.dynamicload": {
+			"scripts": [
+				"dynamicload.js"
+			]
+		}
+	},
+	"config": {
+		"_prefix": "eg",
+		"HeaderFooterDynamicLoad": false
+	},
 	"manifest_version": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,11 @@
 	"descriptionmsg": "headerfooter-desc",
 	"type": "other",
 	"AutoloadClasses": {
-		"HeaderFooter": "HeaderFooter.class.php"
+		"HeaderFooter": "HeaderFooter.class.php",
+		"ApiGetHeaderFooter": "ApiGetHeaderFooter.php"
+	},
+	"APIModules": {
+		"getheaderfooter": "ApiGetHeaderFooter"
 	},
 	"Hooks": {
 		"OutputPageParserOutput": [

--- a/extension.json
+++ b/extension.json
@@ -29,7 +29,8 @@
 	},
 	"config": {
 		"_prefix": "eg",
-		"HeaderFooterDynamicLoad": false
+		"HeaderFooterEnableAsyncHeader": false,
+		"HeaderFooterEnableAsyncFooter": false
 	},
 	"manifest_version": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -13,9 +13,8 @@
 		"getheaderfooter": "ApiGetHeaderFooter"
 	},
 	"Hooks": {
-		"OutputPageParserOutput": [
-			"HeaderFooter::hOutputPageParserOutput"
-		]
+		"OutputPageParserOutput": "HeaderFooter::hOutputPageParserOutput",
+		"ResourceLoaderGetConfigVars": "HeaderFooter::onResourceLoaderGetConfigVars"
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "modules",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,3 +1,8 @@
 {
-	"headerfooter-desc": "Enables per-page/per-namespace headers and footers"
+	"headerfooter-desc": "Enables per-page/per-namespace headers and footers",
+	"apihelp-getheaderfooter-description": "Retrieve the parsed output of a header or footer in the context of a certain page.",
+	"apihelp-getheaderfooter-summary": "Retrieve the parsed output of a header or footer in the context of a certain page.",
+	"apihelp-getheaderfooter-param-contexttitle": "The title of the page that the header or footer is being added to.",
+	"apihelp-getheaderfooter-param-messageid": "Which header or footer is being requested (e.g. a namespace header)",
+	"apihelp-getheaderfooter-example-1": "Get the NS_MAIN footer for Main Page"
 }

--- a/modules/dynamicload.js
+++ b/modules/dynamicload.js
@@ -1,5 +1,13 @@
 
-var extHeaderFooterBlocks = [ "hf-nsheader", "hf-header", "hf-footer", "hf-nsfooter" ];
+var egHeaderFooter = mw.config.get( 'egHeaderFooter' );
+
+if ( egHeaderFooter.enableAsyncHeader ) {
+	var extHeaderFooterBlocks = [ "hf-nsheader", "hf-header" ];
+}
+else {
+	var extHeaderFooterBlocks = [];
+}
+extHeaderFooterBlocks = extHeaderFooterBlocks.concat( [ "hf-footer", "hf-nsfooter" ] );
 
 for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
 	var block = extHeaderFooterBlocks[i];
@@ -19,14 +27,6 @@ for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
 
 		$.get(
 			mw.config.get("wgScriptPath") + "/api.php",
-			// {
-			// 	action: "query",
-			// 	meta: "allmessages",
-			// 	ammessages: msgId,
-			// 	amenableparser: 1,
-			// 	amtitle: mw.config.get('wgPageName'),
-			// 	format: "json"
-			// },
 			{
 				action: "getheaderfooter",
 				messageid: msgId,
@@ -37,7 +37,9 @@ for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
 				// var blockText = response.query.allmessages[0]["*"];
 				var blockText = response.getheaderfooter.result;
 				$( "#" + msgId ).html( blockText );
-				$( "#" + msgId ).find( "#headertabs" ).tabs();
+				$( "#" + msgId ).find( "#headertabs" ).each( function(i,e) {
+					$(e).tabs();
+				});
 			}
 		)
 

--- a/modules/dynamicload.js
+++ b/modules/dynamicload.js
@@ -1,0 +1,38 @@
+
+var extHeaderFooterBlocks = [ "hf-nsheader", "hf-header", "hf-footer", "hf-nsfooter" ];
+
+for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
+	var block = extHeaderFooterBlocks[i];
+
+	$( "." + block ).each( function( i, e ) {
+
+		// FIXME: At some point, put some method of indicating unloaded content here
+
+		// FIXME: At some point, add method to further delay loading of dynamic
+		//        footers. Headers should be loaded right away, but footers should
+		//        only be loaded if the user can see them (or is scrolling toward
+		//        them).
+
+		// Message ID of block (header or footer) is in the HTML ID. hf-nsheader
+		// will have an ID like hf-nsheader-Help for the help namespace.
+		var msgId = $(e).attr('id');
+
+		$.get(
+			mw.config.get("wgScriptPath") + "/api.php",
+			{
+				action: "query",
+				meta: "allmessages",
+				ammessages: msgId,
+				amenableparser: 1,
+				amtitle: mw.config.get('wgPageName'),
+				format: "json"
+			},
+			function ( response ) {
+				var blockText = response.query.allmessages[0]["*"];
+				$("#" + msgId).html( blockText );
+			}
+		)
+
+	} );
+
+}

--- a/modules/dynamicload.js
+++ b/modules/dynamicload.js
@@ -19,16 +19,23 @@ for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
 
 		$.get(
 			mw.config.get("wgScriptPath") + "/api.php",
+			// {
+			// 	action: "query",
+			// 	meta: "allmessages",
+			// 	ammessages: msgId,
+			// 	amenableparser: 1,
+			// 	amtitle: mw.config.get('wgPageName'),
+			// 	format: "json"
+			// },
 			{
-				action: "query",
-				meta: "allmessages",
-				ammessages: msgId,
-				amenableparser: 1,
-				amtitle: mw.config.get('wgPageName'),
+				action: "getheaderfooter",
+				messageid: msgId,
+				contexttitle: mw.config.get('wgPageName'),
 				format: "json"
 			},
 			function ( response ) {
-				var blockText = response.query.allmessages[0]["*"];
+				// var blockText = response.query.allmessages[0]["*"];
+				var blockText = response.getheaderfooter.result;
 				$("#" + msgId).html( blockText );
 			}
 		)

--- a/modules/dynamicload.js
+++ b/modules/dynamicload.js
@@ -36,7 +36,8 @@ for ( var i = 0; i < extHeaderFooterBlocks.length; i++ ) {
 			function ( response ) {
 				// var blockText = response.query.allmessages[0]["*"];
 				var blockText = response.getheaderfooter.result;
-				$("#" + msgId).html( blockText );
+				$( "#" + msgId ).html( blockText );
+				$( "#" + msgId ).find( "#headertabs" ).tabs();
 			}
 		)
 


### PR DESCRIPTION
Rather than generate and load headers/footers during page generation, optionally load the page first, then request them asynchronously.

Adds two config variables:
* `$egHeaderFooterEnableAsyncHeader`
* `$egHeaderFooterEnableAsyncFooter`

Adds `ApiGetHeaderFooter.php` which provides the API action `getheaderfooter`, e.g. `api.php?action=getheaderfooter&contexttitle=Main_Page&messageid=Hf-nsfooter-`

