### PR TITLE
Update for newer Mediawiki compatibility

### DIFF
--- a/ApiGetHeaderFooter.php
+++ b/ApiGetHeaderFooter.php
@@ -17,7 +17,7 @@ class ApiGetHeaderFooter extends ApiBase {
 		$params = $this->extractRequestParams();
 		$contextTitle = Title::newFromDBkey( $params['contexttitle'] );
 		if ( ! $contextTitle ) {
-			$this->dieUsage( "Not a valid contexttitle.", 'notarget' );
+			$this->dieWithError( "Not a valid contexttitle.", 'notarget' );
 		}
 
 		$messageId = $params['messageid'];


### PR DESCRIPTION
In the Mediawiki 1.32 Release Notes:  

> The following deprecated methods have been removed:
>     ApiBase::dieUsage() (deprecated in 1.29)

dieUsage() was replaced with dieWithError() in 1.29