### PR TITLE
Support global header & footer messages

### DIFF
--- a/HeaderFooter.class.php
+++ b/HeaderFooter.class.php
@@ -21,12 +21,15 @@ class HeaderFooter
 
 		$text = $parserOutput->getText();
 
-		$nsheader = self::conditionalInclude( $text, '__NONSHEADER__', 'hf-nsheader', $ns );
-		$header   = self::conditionalInclude( $text, '__NOHEADER__',   'hf-header', $name );
-		$footer   = self::conditionalInclude( $text, '__NOFOOTER__',   'hf-footer', $name );
-		$nsfooter = self::conditionalInclude( $text, '__NONSFOOTER__', 'hf-nsfooter', $ns );
+		$globalheader = self::conditionalInclude( $text, '__NOGLOBALHEADER__', 'hf-global-header', null );
+		$nsheader     = self::conditionalInclude( $text, '__NONSHEADER__', 'hf-nsheader', $ns );
+		$header       = self::conditionalInclude( $text, '__NOHEADER__', 'hf-header', $name );
+		$footer       = self::conditionalInclude( $text, '__NOFOOTER__', 'hf-footer', $name );
+		$nsfooter     = self::conditionalInclude( $text, '__NONSFOOTER__', 'hf-nsfooter', $ns );
+		$globalfooter = self::conditionalInclude( $text, '__NOGLOBALFOOTER__', 'hf-global-footer', null );
 
-		$parserOutput->setText( $nsheader . $header . $text . $footer . $nsfooter );
+		$parserOutput->setText(
+			$globalheader . $nsheader . $header . $text . $footer . $nsfooter . $globalfooter );
 
 		global $egHeaderFooterEnableAsyncHeader, $egHeaderFooterEnableAsyncFooter;
 		if ( $egHeaderFooterEnableAsyncFooter || $egHeaderFooterEnableAsyncHeader ) {
@@ -53,7 +56,7 @@ class HeaderFooter
 			return null;
 		}
 
-		$msgId = "$class-$unique"; // also HTML ID
+		$msgId = $unique === null ? $class : "$class-$unique"; // also HTML ID
 		$div = "<div class='$class' id='$msgId'>";
 
 		global $egHeaderFooterEnableAsyncHeader, $egHeaderFooterEnableAsyncFooter;

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "HeaderFooter",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"author": "Jean-Lou Dupont, James Montalvo, Douglas Mason",
 	"url": "http://mediawiki.org/wiki/Extension:HeaderFooter",
 	"descriptionmsg": "headerfooter-desc",


### PR DESCRIPTION
In case a wiki wants to use HeaderFooter to print the same message on the entire wiki, this way not every namespace needs to be given the same message. Also then you don't need to anticipate new namespace names. (This is [my use case for the extension](https://river.me/blog/top-schedule/))