### PR TITLE
Fixes duplicated `mw-parser-output` element

### DIFF
--- a/HeaderFooter.class.php
+++ b/HeaderFooter.class.php
@@ -19,7 +19,9 @@ class HeaderFooter
 		$ns = $wgTitle->getNsText();
 		$name = $wgTitle->getPrefixedDBKey();
 
-		$text = $parserOutput->getText();
+		// Get output markup omitting the `mw-parser-output` wrapper
+		// because the wrapper will be added later by $parserOutput->setText
+		$text = $parserOutput->getText( [ 'wrapperDivClass' => '' ] );
 
 		$nsheader = self::conditionalInclude( $text, '__NONSHEADER__', 'hf-nsheader', $ns );
 		$header   = self::conditionalInclude( $text, '__NOHEADER__',   'hf-header', $name );


### PR DESCRIPTION
By default, both `ParserOutput::getText` and `ParserOutput::setText` wrap contents returned and set with the default wrapper element which is `<div class="mw-parser-output">`.

This leads to duplicated wrapped `<div class="mw-parser-output">` appearing on wiki pages.

The patch instructs the first `getText` to omit wrapping via providing a  `wrapperDivClass` parameter that effectively removes any wrapping from the markup returned, and the wrapper is added later when contents are set via `setText`.